### PR TITLE
fix truncation on json conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+- Fix [#6](https://github.com/gdbarron/VenafiPS/issues/6), truncation on json conversion.
+
 ## 3.0
 - Rebrand from VenafiTppPS to VenafiPS as the module will now support Venafi products other than TPP.  Functions with -Tpp in the name will now be TPP only, -Vaas will be for Venafi as a Service only, and -Venafi will be both
 - Rename `New-TppSession` to `New-VenafiSession` and add support for Venafi as a Service.  Use the parameter `-VaasKey`

--- a/VenafiPS/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiPS/Private/Write-VerboseWithSecret.ps1
@@ -54,7 +54,7 @@ function Write-VerboseWithSecret {
         $processMe = $InputObject
         if ($InputObject.GetType().FullName -ne 'System.String') {
             # if hashtable or other object, convert to json first
-            $processMe = $InputObject | ConvertTo-Json -Depth 5
+            $processMe = $InputObject | ConvertTo-Json -Depth 20
         }
 
         foreach ($prop in $PropertyName) {

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -123,7 +123,7 @@ function Invoke-VenafiRestMethod {
     if ( $Body ) {
         $restBody = $Body
         if ( $Method -ne 'Get' ) {
-            $restBody = ConvertTo-Json $Body -Depth 5
+            $restBody = ConvertTo-Json $Body -Depth 20
         }
         $params.Body = $restBody
     }


### PR DESCRIPTION
fix #6, conversion to json was being truncated as the depth was deeper than 5.  upped value to 20.