### PR TITLE
Move to Invoke-WebRequest, add -CountOnly option to Find-TppCertificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+- Add `-CountOnly` to `Find-TppCertificate` to return the number of certificates found based on the filters provided, [#12](https://github.com/gdbarron/VenafiPS/issues/12)
+- Move from `Invoke-RestMethod` to `Invoke-WebRequest` in `Invoke-VenafiRestMethod` so we get response headers used with `-CountOnly` above.
+
 ## 3.0.3
 - Fix [#10](https://github.com/gdbarron/VenafiPS/issues/10), Get-VenafiCertificate not recognizing session.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 3.1.0
 - Add `-CountOnly` to `Find-TppCertificate` to return the number of certificates found based on the filters provided, [#12](https://github.com/gdbarron/VenafiPS/issues/12)
-- Move from `Invoke-RestMethod` to `Invoke-WebRequest` in `Invoke-VenafiRestMethod` so we get response headers used with `-CountOnly` above.
+- Move from `Invoke-RestMethod` to `Invoke-WebRequest` in `Invoke-VenafiRestMethod` so we get response headers, to be used with `-CountOnly` above.  `Invoke-VenafiRestMethod` has a new parameter, `-FullResponse`, to retrieve the complete response, not just content value.
+- Add `New-HttpQueryString` private function to support HEAD api calls which require a query string and not body.
+- Fix `Test-TppIdentityFormat` which was failing when the identity guid was surrounded with curly braces
+- Replace `-Limit` parameter and standardize on `-First`
 
 ## 3.0.3
 - Fix [#10](https://github.com/gdbarron/VenafiPS/issues/10), Get-VenafiCertificate not recognizing session.

--- a/VenafiPS/Private/New-HttpQueryString.ps1
+++ b/VenafiPS/Private/New-HttpQueryString.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+    Generate http query string
+.LINK
+    https://powershellmagazine.com/2019/06/14/pstip-a-better-way-to-generate-http-query-strings-in-powershell/
+#>
+function New-HttpQueryString
+{
+    [CmdletBinding()]
+    param 
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Uri,
+
+        [Parameter(Mandatory = $true)]
+        [Hashtable]
+        $QueryParameter
+    )
+    # Add System.Web
+    Add-Type -AssemblyName System.Web
+    
+    # Create a http name value collection from an empty string
+    $nvCollection = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+    
+    foreach ($key in $QueryParameter.Keys)
+    {
+        $nvCollection.Add($key, $QueryParameter.$key)
+    }
+    
+    # Build the uri
+    $uriRequest = [System.UriBuilder]$uri
+    $uriRequest.Query = $nvCollection.ToString()
+    
+    return $uriRequest.Uri.OriginalString
+}

--- a/VenafiPS/Private/Test-TppIdentityFormat.ps1
+++ b/VenafiPS/Private/Test-TppIdentityFormat.ps1
@@ -13,7 +13,7 @@ function Test-TppIdentityFormat {
     process {
 
         if ( $Type -eq 'Universal' ) {
-            $Identity -match '^(AD|LDAP)+.+:\w{32}$' -or $Identity -match '^local:\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$'
+            $Identity -match '^(AD|LDAP)+.+:\w{32}$' -or $Identity -match '^local:\{?\w{8}-\w{4}-\w{4}-\w{4}-\w{12}\}?$'
         } else {
             #TODO
         }

--- a/VenafiPS/Public/Find-TppCertificate.ps1
+++ b/VenafiPS/Public/Find-TppCertificate.ps1
@@ -129,6 +129,9 @@ Only include certificates with validation enabled or disabled
 .PARAMETER ValidationState
 Find certificates with a validation state of Blank, Success, or Failure
 
+.PARAMETER CountOnly
+Return the count of certificates found from the query as opposed to the certificates themselves
+
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
 
@@ -136,7 +139,7 @@ Session object created from New-VenafiSession method.  The value defaults to the
 Path, Guid
 
 .OUTPUTS
-TppObject
+TppObject, Int when CountOnly provided
 
 .EXAMPLE
 Find-TppCertificate -ExpireBefore "2018-01-01"

--- a/VenafiPS/Public/Find-TppCertificate.ps1
+++ b/VenafiPS/Public/Find-TppCertificate.ps1
@@ -14,7 +14,7 @@ Guid which represents a starting path
 .PARAMETER Recursive
 Search recursively starting from the search path.
 
-.PARAMETER Limit
+.PARAMETER First
 Limit how many items are returned.  Default is 0 for no limit.
 It is definitely recommended to filter on another property when searching with no limit.
 
@@ -146,11 +146,11 @@ Find-TppCertificate -ExpireBefore "2018-01-01"
 Find all certificates expiring before a certain date
 
 .EXAMPLE
-Find-TppCertificate -ExpireBefore "2018-01-01" -Limit 5
+Find-TppCertificate -ExpireBefore "2018-01-01" -First 5
 Find 5 certificates expiring before a certain date
 
 .EXAMPLE
-Find-TppCertificate -ExpireBefore "2018-01-01" -Limit 5 -Offset 2
+Find-TppCertificate -ExpireBefore "2018-01-01" -First 5 -Offset 2
 Find 5 certificates expiring before a certain date, starting at the 3rd certificate found.
 
 .EXAMPLE
@@ -166,7 +166,7 @@ Find-TppCertificate -Path '\VED\Policy\My Policy' -Recursive
 Find all certificates in a specific path and all subfolders
 
 .EXAMPLE
-Find-TppCertificate -ExpireBefore "2018-01-01" -Limit 5 | Get-TppCertificateDetail
+Find-TppCertificate -ExpireBefore "2018-01-01" -First 5 | Get-TppCertificateDetail
 Get detailed certificate info on the first 5 certificates expiring before a certain date
 
 .EXAMPLE
@@ -217,7 +217,8 @@ function Find-TppCertificate {
         [Switch] $Recursive,
 
         [Parameter()]
-        [int] $Limit = 0,
+        [Alias('Limit')]
+        [int] $First = 0,
 
         [Parameter()]
         [int] $Offset,
@@ -361,7 +362,7 @@ function Find-TppCertificate {
             Method        = 'Get'
             UriLeaf       = 'certificates/'
             Body          = @{
-                Limit = $Limit
+                Limit = $First
             }
         }
 

--- a/VenafiPS/Public/Find-TppIdentity.ps1
+++ b/VenafiPS/Public/Find-TppIdentity.ps1
@@ -9,8 +9,8 @@ You can specify individual identity types to search for or all
 .PARAMETER Name
 The individual identity, group identity, or distribution group name to search for
 
-.PARAMETER Limit
-Limit how many items are returned, the default is 500, but is limited by the provider.
+.PARAMETER First
+First how many items are returned, the default is 500, but is limited by the provider.
 
 .PARAMETER IncludeUsers
 Include user identity type in search
@@ -64,7 +64,8 @@ function Find-TppIdentity {
         [String[]] $Name,
 
         [Parameter(ParameterSetName = 'Find')]
-        [int] $Limit = 500,
+        [Alias('Limit')]
+        [int] $First = 500,
 
         [Parameter(ParameterSetName = 'Find')]
         [Switch] $IncludeUsers,
@@ -110,7 +111,7 @@ function Find-TppIdentity {
                     UriLeaf    = 'Identity/Browse'
                     Body       = @{
                         Filter       = 'placeholder'
-                        Limit        = $Limit
+                        Limit        = $First
                         IdentityType = $identityType
                     }
                 }

--- a/VenafiPS/Public/Get-TppPermission.ps1
+++ b/VenafiPS/Public/Get-TppPermission.ps1
@@ -177,7 +177,7 @@ function Get-TppPermission {
                 }
             }
 
-            $uriBase = ('Permissions/object/{{{0}}}' -f $thisTppObject.Guid )
+            $uriBase = ('Permissions/Object/{{{0}}}' -f $thisTppObject.Guid )
             $params.UriLeaf = $uriBase
 
             try {

--- a/VenafiPS/Public/Get-TppPermission.ps1
+++ b/VenafiPS/Public/Get-TppPermission.ps1
@@ -98,7 +98,8 @@ function Get-TppPermission {
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
                     $true
-                } else {
+                }
+                else {
                     throw "'$_' is not a valid DN path"
                 }
             })]
@@ -114,7 +115,8 @@ function Get-TppPermission {
         [ValidateScript( {
                 if ( $_ | Test-TppIdentityFormat ) {
                     $true
-                } else {
+                }
+                else {
                     throw "'$_' is not a valid Identity format.  See https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-IdentityInformation.php."
                 }
             })]
@@ -138,8 +140,8 @@ function Get-TppPermission {
 
         $params = @{
             VenafiSession = $VenafiSession
-            Method     = 'Get'
-            UriLeaf    = 'placeholder'
+            Method        = 'Get'
+            UriLeaf       = 'placeholder'
         }
     }
 
@@ -175,14 +177,15 @@ function Get-TppPermission {
                 }
             }
 
-            $uriBase = ('Permissions/Object/{{{0}}}' -f $thisTppObject.Guid )
+            $uriBase = ('Permissions/object/{{{0}}}' -f $thisTppObject.Guid )
             $params.UriLeaf = $uriBase
 
             try {
                 # get list of identities permissioned to this object
                 $identities = Invoke-TppRestMethod @params
-            } catch {
-                Write-Error ("Couldn't obtain list of permissions for {0}.  $_" -f $thisTppObject.Path)
+            }
+            catch {
+                Write-Error ('Couldn''t obtain list of permissions for {0}.  {1}' -f $thisTppObject.Path, $_ | Out-String)
                 continue
             }
 
@@ -200,7 +203,8 @@ function Get-TppPermission {
                     # format of local is local:universalId
                     $type, $id = $thisId.Split(':')
                     $params.UriLeaf += "/local/$id"
-                } else {
+                }
+                else {
                     # external source, eg. AD, LDAP
                     # format is type+name:universalId
                     $type, $name, $id = $thisId -Split { $_ -in '+', ':' }
@@ -233,14 +237,15 @@ function Get-TppPermission {
                         }
 
                         $attribParams = @{
-                            IdentityId = $thisReturnObject.IdentityId
+                            IdentityId    = $thisReturnObject.IdentityId
                             VenafiSession = $VenafiSession
                         }
                         try {
                             $attribResponse = Get-TppIdentityAttribute @attribParams
                             $thisReturnObject.IdentityPath = $attribResponse.Attributes.FullName
                             $thisReturnObject.IdentityName = $attribResponse.Attributes.Name
-                        } catch {
+                        }
+                        catch {
                             Write-Error "Couldn't obtain identity attributes for $($attribParams.IdentityId).  $_"
                         }
 
@@ -264,7 +269,8 @@ function Get-TppPermission {
                                 ExplicitPermissions = [TppPermission] $response.ExplicitPermissions
                                 ImplicitPermissions = [TppPermission] $response.ImplicitPermissions
                             }
-                        } else {
+                        }
+                        else {
                             $thisReturnObject | Add-Member @{
                                 EffectivePermissions = [TppPermission] $response.EffectivePermissions
                             }
@@ -272,7 +278,8 @@ function Get-TppPermission {
 
                         $thisReturnObject
                     }
-                } catch {
+                }
+                catch {
                     Write-Error ('Couldn''t obtain permission set for path {0}, identity {1}.  {2}' -f $thisTppObject.Path, $thisId, $_)
                 }
             }

--- a/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
+++ b/VenafiPS/Public/Invoke-VenafiRestMethod.ps1
@@ -116,6 +116,8 @@ function Invoke-VenafiRestMethod {
         $restBody = $Body
         switch ($Method.ToLower()) {
             'head' {
+                # a head method requires the params be provided as a query string, not body
+                # invoke-webrequest does not do this so we have to build the string manually
                 $newUri = New-HttpQueryString -Uri $uri -QueryParameter $Body
                 $params.Uri = $newUri
                 $params.Body = $null

--- a/VenafiPS/Public/Read-TppLog.ps1
+++ b/VenafiPS/Public/Read-TppLog.ps1
@@ -32,7 +32,7 @@ Filter matching results of Value1
 .PARAMETER Value2
 Filter matching results of Value2
 
-.PARAMETER Limit
+.PARAMETER First
 Specify the number of items to retrieve, starting with most recent.  The default is 100 and there is no maximum.
 
 .PARAMETER VenafiSession
@@ -60,7 +60,7 @@ PSCustomObject with properties:
     Value2
 
 .EXAMPLE
-Read-TppLog -Limit 10
+Read-TppLog -First 10
 Get the most recent 10 log items
 
 .EXAMPLE
@@ -118,7 +118,8 @@ function Read-TppLog {
         [int] $Value2,
 
         [Parameter()]
-        [Int] $Limit,
+        [Alias('Limit')]
+        [Int] $First,
 
         [Parameter()]
         [VenafiSession] $VenafiSession = $script:VenafiSession
@@ -165,8 +166,8 @@ function Read-TppLog {
                 $params.Body.Add('Value2', $Value2)
             }
 
-            'Limit' {
-                $params.Body.Add('Limit', $Limit)
+            'First' {
+                $params.Body.Add('Limit', $First)
             }
         }
     }

--- a/VenafiPS/VenafiPS.psd1
+++ b/VenafiPS/VenafiPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VenafiPS.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.0.3'
+ModuleVersion = '3.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
- Add `-CountOnly` to `Find-TppCertificate` to return the number of certificates found based on the filters provided, #12 
- Move from `Invoke-RestMethod` to `Invoke-WebRequest` in `Invoke-VenafiRestMethod` so we get response headers, to be used with `-CountOnly` above.  `Invoke-VenafiRestMethod` has a new parameter, `-FullResponse`, to retrieve the complete response, not just content value.
- Add `New-HttpQueryString` private function to support HEAD api calls which require a query string and not body.
- Fix `Test-TppIdentityFormat` which was failing when the identity guid was surrounded with curly braces
- Replace `-Limit` parameter and standardize on `-First`