### PR TITLE
Add EventId to Read-TppLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.2
+- Add `-EventId` parameter to `Read-TppLog` to filter by a specific event id.
+- Add EventId to `Read-TppLog` output.  The value matches the hex value seen in Event Definitions in TPP.
+
 ## 3.1.1
 - Add -UseBasicParsing to `Invoke-WebRequest` to avoid IE profile error
 


### PR DESCRIPTION
- Add `-EventId` parameter to `Read-TppLog` to filter by a specific event id.
- Add EventId to `Read-TppLog` output.  The value matches the hex value seen in Event Definitions in TPP.
