### PR TITLE
-Force parameter for Revoke functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.3
+- Add `-Force` parameter to `Revoke-TppToken` and `Revoke-TppCertificate` to bypass confirmation prompt
+
 ## 3.1.2
 - Add `-EventId` parameter to `Read-TppLog` to filter by a specific event id.
 - Add EventId to `Read-TppLog` output.  The value matches the hex value seen in Event Definitions in TPP.

--- a/VenafiPS/Public/Revoke-TppCertificate.ps1
+++ b/VenafiPS/Public/Revoke-TppCertificate.ps1
@@ -32,6 +32,9 @@ Provide this switch to mark the certificate as disabled and no new certificate w
 .PARAMETER Wait
 Wait for the requested revocation to be complete
 
+.PARAMETER Force
+Override the confirmation prompt
+
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
 
@@ -49,6 +52,10 @@ $cert | Revoke-TppCertificate -Reason 2
 Revoke the certificate with a reason of the CA being compromised
 
 .EXAMPLE
+$cert | Revoke-TppCertificate -Force
+Revoke the certificate bypassing the confirmation prompt
+
+.EXAMPLE
 Revoke-TppCertificate -Path '\VED\Policy\My folder\app.mycompany.com' -Reason 2 -Wait
 Revoke the certificate with a reason of the CA being compromised and wait for it to complete
 
@@ -63,13 +70,10 @@ https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certif
 
 #>
 function Revoke-TppCertificate {
-    [CmdletBinding(DefaultParameterSetName = 'ByObject', SupportsShouldProcess, ConfirmImpact = 'High')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param (
 
-        [Parameter(Mandatory, ParameterSetName = 'ByObject', ValueFromPipeline)]
-        [TppObject] $InputObject,
-
-        [Parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'ByPath')]
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
@@ -96,6 +100,9 @@ function Revoke-TppCertificate {
         [Switch] $Wait,
 
         [Parameter()]
+        [switch] $Force,
+
+        [Parameter()]
         [VenafiSession] $VenafiSession = $script:VenafiSession
     )
 
@@ -111,12 +118,6 @@ function Revoke-TppCertificate {
     }
 
     process {
-
-        Write-Verbose $PsCmdlet.ParameterSetName
-
-        if ( $PSBoundParameters.ContainsKey('InputObject') ) {
-            $path = $InputObject.Path
-        }
 
         Write-Verbose "Revoking $Path..."
 
@@ -134,6 +135,10 @@ function Revoke-TppCertificate {
 
         if ( $Disable ) {
             $params.Body.Disable = $true
+        }
+
+        if ( $Force ) {
+            $ConfirmPreference = 'None'
         }
 
         if ( $PSCmdlet.ShouldProcess($Path, 'Revoke certificate') ) {

--- a/VenafiPS/Public/Revoke-TppCertificate.ps1
+++ b/VenafiPS/Public/Revoke-TppCertificate.ps1
@@ -33,7 +33,7 @@ Provide this switch to mark the certificate as disabled and no new certificate w
 Wait for the requested revocation to be complete
 
 .PARAMETER Force
-Override the confirmation prompt
+Bypass the confirmation prompt
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.

--- a/VenafiPS/Public/Revoke-TppToken.ps1
+++ b/VenafiPS/Public/Revoke-TppToken.ps1
@@ -25,7 +25,7 @@ Session object created from New-VenafiSession method.  The value defaults to the
 TppToken
 
 .OUTPUTS
-Version
+none
 
 .EXAMPLE
 Revoke-TppToken

--- a/VenafiPS/Public/Revoke-TppToken.ps1
+++ b/VenafiPS/Public/Revoke-TppToken.ps1
@@ -15,6 +15,9 @@ Access token to be revoked.  Provide a credential object with the access token a
 .PARAMETER TppToken
 Token object obtained from New-TppToken
 
+.PARAMETER Force
+Override the confirmation prompt
+
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
 
@@ -27,6 +30,10 @@ Version
 .EXAMPLE
 Revoke-TppToken
 Revoke token stored in session variable from New-VenafiSession
+
+.EXAMPLE
+Revoke-TppToken -Force
+Revoke token bypassing confirmation prompt
 
 .EXAMPLE
 Revoke-TppToken -AuthServer venafi.company.com -AccessToken $cred
@@ -64,6 +71,9 @@ function Revoke-TppToken {
 
         [Parameter(Mandatory, ParameterSetName = 'TppToken', ValueFromPipeline)]
         [pscustomobject] $TppToken,
+
+        [Parameter()]
+        [switch] $Force,
 
         [Parameter(ParameterSetName = 'Session')]
         [VenafiSession] $VenafiSession = $script:VenafiSession
@@ -114,7 +124,11 @@ function Revoke-TppToken {
 
         Write-Verbose ($params | Out-String)
 
-        if ( $PSCmdlet.ShouldProcess($target, 'Revoke token') ) {
+        if ( $Force ) {
+            $ConfirmPreference = 'None'
+        }
+
+        if ( $PSCmdlet.ShouldProcess($target) ) {
             Invoke-TppRestMethod @params
         }
     }

--- a/VenafiPS/Public/Revoke-TppToken.ps1
+++ b/VenafiPS/Public/Revoke-TppToken.ps1
@@ -16,7 +16,7 @@ Access token to be revoked.  Provide a credential object with the access token a
 Token object obtained from New-TppToken
 
 .PARAMETER Force
-Override the confirmation prompt
+Bypass the confirmation prompt
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.


### PR DESCRIPTION
- Add `-Force` parameter to `Revoke-TppToken` and `Revoke-TppCertificate` to bypass confirmation prompt