### PR TITLE
Set-TppAttribute updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.5
+- Update `Set-TppAttribute`
+  - Change from name and value parameters to hashtable
+  - API calls were sending deprecated payloads, fix this
+  - Add custom field validation and `-BypassValidation` switch.  The validation is field type aware and will validate string, date, list, and identity.
+
 ## 3.1.4
 - Fix [#19](https://github.com/gdbarron/VenafiPS/issues/19), `Revoke-TppToken -AccessToken` not decrypting password
 

--- a/VenafiPS/Public/Set-TppAttribute.ps1
+++ b/VenafiPS/Public/Set-TppAttribute.ps1
@@ -51,6 +51,7 @@ https://docs.venafi.com/Docs/21.2/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-wr
 function Set-TppAttribute {
 
     [CmdletBinding(SupportsShouldProcess)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Being flagged incorrectly')]
 
     param (
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]

--- a/VenafiPS/Public/Set-TppAttribute.ps1
+++ b/VenafiPS/Public/Set-TppAttribute.ps1
@@ -1,21 +1,18 @@
 <#
 .SYNOPSIS
-Adds a value to an attribute
+Sets a value on an attribute
 
 .DESCRIPTION
-Write a value to the object's configuration.  This function will append by default.  Attributes can have multiple values which may not be the intended use.  To ensure you only have one value for an attribute, use the Overwrite switch.
+Set a value on an attribute.  The attribute can either be built-in or custom.
 
-.PARAMETER ObjectDN
+.PARAMETER Path
 Path to the object to modify
 
-.PARAMETER AttributeName
-Name of the attribute to modify.  If modifying a custom field, use the Label.
+.PARAMETER Attribute
+Hashtable with names and values to be set.  If setting a custom field, you can use either the name or guid as the key.
 
-.PARAMETER Value
-Value or list of values to write to the attribute.
-
-.PARAMETER NoClobber
-Append existing values as opposed to replacing which is the default
+.PARAMETER BypassValidation
+Bypass data validation.  Only appicable to custom fields.
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
@@ -24,17 +21,18 @@ Session object created from New-VenafiSession method.  The value defaults to the
 Path
 
 .OUTPUTS
-PSCustomObject with the following properties:
-    DN = path to object
-    Success = boolean indicating success or failure
-    Error = Error message in case of failure
+None
 
 .EXAMPLE
-Set-TppAttribute -Path '\VED\Policy\My Folder\app.company.com -AttributeName 'My custom field Label' -Value 'new custom value'
-Set value on custom field.  This will add to any existing value.
+Set-TppAttribute -Path '\VED\Policy\My Folder\app.company.com -Attribute @{'My custom field Label'='new custom value'}
+Set value on custom field
 
 .EXAMPLE
-Set-TppAttribute -Path '\VED\Policy\My Folder\app.company.com -AttributeName 'Consumers' -Value '\VED\Policy\myappobject.company.com' -Overwrite
+Set-TppAttribute -Path '\VED\Policy\My Folder\app.company.com -Attribute @{'DateField'='hi'} -BypassValidation
+Set value on custom field bypassing field validation
+
+.EXAMPLE
+Set-TppAttribute -Path '\VED\Policy\My Folder\app.company.com -Attribute @{'Consumers'='\VED\Policy\myappobject.company.com'}
 Set value on a certificate by overwriting any existing values
 
 .LINK
@@ -44,13 +42,18 @@ http://VenafiPS.readthedocs.io/en/latest/functions/Set-TppAttribute/
 https://github.com/gdbarron/VenafiPS/blob/main/VenafiPS/Code/Public/Set-TppAttribute.ps1
 
 .LINK
-https://docs.venafi.com/Docs/20.4SDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-addvalue.php?tocpath=Web%20SDK%7CConfig%20programming%20interface%7C_____4
+https://docs.venafi.com/Docs/21.2/TopNav/Content/SDK/WebSDK/r-SDK-POST-Metadata-Set.php?tocpath=Platform%20SDK%7CWeb%20SDK%20REST%7CCertificate%20end%20points%20for%20TLS%7CMetadata%20custom%20fields%20API%7C_____17
+
+.LINK
+https://docs.venafi.com/Docs/21.2/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config-write.php?tocpath=Platform%20SDK%7CWeb%20SDK%20REST%7CConfiguration%20end%20points%7CConfig%20API%7C_____36
 
 #>
 function Set-TppAttribute {
+
     [CmdletBinding(SupportsShouldProcess)]
+
     param (
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
                 if ( $_ | Test-TppDnPath ) {
@@ -64,15 +67,10 @@ function Set-TppAttribute {
         [String[]] $Path,
 
         [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [String] $AttributeName,
-
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [String[]] $Value,
+        [hashtable] $Attribute,
 
         [Parameter()]
-        [Switch] $NoClobber,
+        [switch] $BypassValidation,
 
         [Parameter()]
         [VenafiSession] $VenafiSession = $script:VenafiSession
@@ -83,17 +81,72 @@ function Set-TppAttribute {
 
         $params = @{
             VenafiSession = $VenafiSession
-            Method     = 'Post'
+            Method        = 'Post'
         }
 
-        if ($NoClobber) {
-            $params += @{
-                UriLeaf = 'config/AddValue'
+        $baseFields = @()
+        $customFields = @()
+
+        $Attribute.GetEnumerator() | ForEach-Object {
+
+            $thisKey = $_.Key
+            $thisValue = $_.Value
+            $customFieldError = $null
+
+            $customField = $VenafiSession.CustomField | Where-Object { $_.Label -eq $thisKey -or $_.Guid -eq $thisKey }
+            if ( $customField ) {
+                switch ( $customField.Type.ToString() ) {
+                    '1' {
+                        # string
+                        if ( $customField.RegularExpression -and $thisValue -notmatch $customField.RegularExpression ) {
+                            $customFieldError = 'regular expression ''{0}'' validation failed' -f $customField.RegularExpression
+                        }
+                    }
+
+                    '2' {
+                        # list
+                        if ( $thisValue -notin $customField.AllowedValues ) {
+                            $customFieldError = 'value is not in the list of allowed values ''{0}''' -f $customField.AllowedValues
+                        }
+                    }
+
+                    '5' {
+                        # identity
+                        if ( -not ($thisValue | Test-TppIdentity -ExistOnly -VenafiSession $VenafiSession) ) {
+                            $customFieldError = 'value is not a valid identity'
+                        }
+                    }
+
+                    '4' {
+                        # date/time
+                        try {
+                            [datetime] $thisValue
+                        }
+                        catch {
+                            $customFieldError = 'value is not a valid date'
+                        }
+                    }
+
+                    Default {
+                        $customFieldError = 'unknown custom field type'
+                    }
+                }
+
+                if ( $customFieldError -and -not $BypassValidation.IsPresent ) {
+                    Write-Error ('The value ''{0}'' for field ''{1}'' encountered an error, {2}' -f $thisValue, $thisKey, $customFieldError)
+                }
+                else {
+                    $customFields += @{
+                        ItemGuid = $customField.Guid
+                        List     = @($thisValue)
+                    }
+                }
             }
-        }
-        else {
-            $params += @{
-                UriLeaf = 'config/Write'
+            else {
+                $baseFields += @{
+                    Name  = $thisKey
+                    Value = $thisValue
+                }
             }
         }
     }
@@ -102,51 +155,38 @@ function Set-TppAttribute {
 
         foreach ($thisDn in $Path) {
 
-            $realAttributeName = $AttributeName
-            $field = $VenafiSession.CustomField | Where-Object {$_.Label -eq $AttributeName}
-            if ( $field ) {
-                $realAttributeName = $field.Guid
-                Write-Verbose ("Updating custom field.  Name: {0}, Guid: {1}" -f $AttributeName, $field.Guid)
-            }
+            if ( $PSCmdlet.ShouldProcess($thisDn) ) {
 
-            $params.Body = @{
-                ObjectDN      = $thisDn
-                AttributeName = $realAttributeName
-            }
+                # built-in fields and custom fields have different APIs and payloads
 
-            # overwrite can accept multiple values at once so pass in the entire list
-            # adding values can not so we must loop
-            if ($NoClobber) {
-                foreach ($thisValue in $Value) {
+                if ( $baseFields.Count -gt 0 ) {
 
-                    $params.Body += @{
-                        Value = $thisValue
+                    $params.UriLeaf = 'config/Write'
+                    $params.Body = @{
+                        ObjectDN      = $thisDn
+                        AttributeData = $baseFields
                     }
-
-                    if ( $PSCmdlet.ShouldProcess($thisDn, 'Add attribute values') ) {
-                        $response = Invoke-TppRestMethod @params
-
-                        [PSCustomObject] @{
-                            DN      = $thisDn
-                            Success = $response.Result -eq [TppConfigResult]::Success
-                            Error   = $response.Error
-                        }
-                    }
-                }
-            }
-            else {
-                $params.Body += @{
-                    Values = $Value
-                }
-
-                if ( $PSCmdlet.ShouldProcess($thisDn, 'Overwrite attribute values') ) {
 
                     $response = Invoke-TppRestMethod @params
 
-                    [PSCustomObject] @{
-                        DN      = $thisDn
-                        Success = $response.Result -eq [TppConfigResult]::Success
-                        Error   = $response.Error
+                    if ( $response.Result -ne [TppConfigResult]::Success ) {
+                        Write-Error $response.Error
+                    }
+                }
+
+                if ( $customFields.Count -gt 0 ) {
+
+                    $params.UriLeaf = 'Metadata/Set'
+                    $params.Body = @{
+                        DN           = $thisDn
+                        GuidData     = $customFields
+                        KeepExisting = $true
+                    }
+
+                    $response = Invoke-TppRestMethod @params
+
+                    if ( $response.Result -ne 0 ) {
+                        Write-Error $response.Error
                     }
                 }
             }


### PR DESCRIPTION
- Update `Set-TppAttribute`
  - Change from name and value parameters to hashtable
  - API calls were sending deprecated payloads, fix this
  - Add custom field validation and `-BypassValidation` switch.  The validation is field type aware and will validate string, date, list, and identity.
