### PR TITLE
Various fixes for Exporting a certificate

### DIFF
--- a/VenafiPS/Private/Write-VerboseWithSecret.ps1
+++ b/VenafiPS/Private/Write-VerboseWithSecret.ps1
@@ -9,7 +9,7 @@ Remove sensitive information when writing verbose info
 JSON string or other object
 
 .PARAMETER SecretName
-Name of secret(s) to hide their values.  Default value is 'Password', 'AccessToken', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization'
+Name of secret(s) to hide their values.  Default value is 'Password', 'AccessToken', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization', 'KeystorePassword', 'tppl-api-key', 'CertficateData'
 
 .INPUTS
 InputObject
@@ -37,7 +37,7 @@ function Write-VerboseWithSecret {
         [psobject] $InputObject,
 
         [Parameter()]
-        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization', 'KeystorePassword', 'tppl-api-key')
+        [string[]] $PropertyName = @('AccessToken', 'Password', 'RefreshToken', 'access_token', 'refresh_token', 'Authorization', 'KeystorePassword', 'tppl-api-key', 'CertificateData')
     )
 
     begin {

--- a/VenafiPS/Public/Export-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Export-VenafiCertificate.ps1
@@ -20,6 +20,9 @@ Include the certificate chain with the exported certificate.  Not supported with
 .PARAMETER FriendlyName
 Label or alias to use.  Permitted with Base64 and PKCS #12 formats.  Required when Format is JKS.  TPP Only.
 
+.PARAMETER IncludePrivateKey
+Include the private key with the exported certificate. Not supported with Base64, DER or PKCS #7 formats.  TPP Only. 
+
 .PARAMETER PrivateKeyPassword
 Password required to include the private key.  Not supported with DER or PKCS #7 formats.  TPP Only.
 You must adhere to the following rules:
@@ -31,7 +34,8 @@ You must adhere to the following rules:
     - Special characters
 
 .PARAMETER KeystorePassword
-Password required to retrieve the certificate in JKS format.  TPP Only.  You must adhere to the following rules:
+Password required to retrieve the certificate in JKS format.  TPP Only. 
+You must adhere to the following rules:
 - Password is at least 12 characters.
 - Comprised of at least three of the following:
     - Uppercase alphabetic letters
@@ -102,6 +106,7 @@ function Export-VenafiCertificate {
         [string] $FriendlyName,
 
         [Parameter(ParameterSetName = 'Tpp')]
+        [Parameter(ParameterSetName = 'TppJks')]
         [switch] $IncludePrivateKey,
 
         [Parameter(ParameterSetName = 'Tpp')]
@@ -157,7 +162,11 @@ function Export-VenafiCertificate {
                 $params.Body.Format = 'JKS'
                 $plainTextPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringUni([System.Runtime.InteropServices.Marshal]::SecureStringToCoTaskMemUnicode($KeystorePassword))
                 $params.Body.KeystorePassword = $plainTextPassword
-
+                
+                if ($IncludePrivateKey -eq $True) {
+                    $params.Body.IncludePrivateKey = $true
+                    $params.Body.Password = $plainTextPassword
+                }
             }
 
             if (-not [string]::IsNullOrEmpty($FriendlyName)) {

--- a/VenafiPS/Public/Export-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Export-VenafiCertificate.ps1
@@ -21,7 +21,7 @@ Include the certificate chain with the exported certificate.  Not supported with
 Label or alias to use.  Permitted with Base64 and PKCS #12 formats.  Required when Format is JKS.  TPP Only.
 
 .PARAMETER IncludePrivateKey
-Include the private key with the exported certificate. Not supported with Base64, DER or PKCS #7 formats.  TPP Only. 
+DEPRECATED. Provide a value for -PrivateKeyPassword.
 
 .PARAMETER PrivateKeyPassword
 Password required to include the private key.  Not supported with DER or PKCS #7 formats.  TPP Only.
@@ -106,10 +106,10 @@ function Export-VenafiCertificate {
         [string] $FriendlyName,
 
         [Parameter(ParameterSetName = 'Tpp')]
-        [Parameter(ParameterSetName = 'TppJks')]
         [switch] $IncludePrivateKey,
 
         [Parameter(ParameterSetName = 'Tpp')]
+        [Parameter(ParameterSetName = 'TppJks')]
         [Alias('SecurePassword')]
         [Security.SecureString] $PrivateKeyPassword,
 
@@ -162,11 +162,6 @@ function Export-VenafiCertificate {
                 $params.Body.Format = 'JKS'
                 $plainTextPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringUni([System.Runtime.InteropServices.Marshal]::SecureStringToCoTaskMemUnicode($KeystorePassword))
                 $params.Body.KeystorePassword = $plainTextPassword
-                
-                if ($IncludePrivateKey -eq $True) {
-                    $params.Body.IncludePrivateKey = $true
-                    $params.Body.Password = $plainTextPassword
-                }
             }
 
             if (-not [string]::IsNullOrEmpty($FriendlyName)) {
@@ -179,6 +174,10 @@ function Export-VenafiCertificate {
                 }
 
                 $params.Body.IncludeChain = $true
+            }
+
+            if ($IncludePrivateKey) {
+                Write-Warning "IncludePrivateKey is DEPRECATED. Provide a value for -PrivateKeyPassword instead."
             }
         }
     }

--- a/VenafiPS/Public/Export-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Export-VenafiCertificate.ps1
@@ -94,6 +94,7 @@ function Export-VenafiCertificate {
         [String] $OutPath,
 
         [Parameter(ParameterSetName = 'Tpp')]
+        [Parameter(ParameterSetName = 'TppJks')]
         [switch] $IncludeChain,
 
         [Parameter(ParameterSetName = 'Tpp')]

--- a/VenafiPS/Public/Export-VenafiCertificate.ps1
+++ b/VenafiPS/Public/Export-VenafiCertificate.ps1
@@ -57,19 +57,19 @@ $certId | Export-VenafiCertificate -Format PEM
 Get certificate data from Venafi as a Service
 
 .EXAMPLE
-$cert | Get-VenafiCertificate -Format 'PKCS #7' -OutPath 'c:\temp'
+$cert | Export-VenafiCertificate -Format 'PKCS #7' -OutPath 'c:\temp'
 Get certificate data and save to a file, TPP
 
 .EXAMPLE
-$cert | Get-VenafiCertificate -Format 'PKCS #7' -IncludeChain
+$cert | Export-VenafiCertificate -Format 'PKCS #7' -IncludeChain
 Get one or more certificates with the certificate chain included, TPP
 
 .EXAMPLE
-$cert | Get-VenafiCertificate -Format 'PKCS #12' -PrivateKeyPassword $cred.password
+$cert | Export-VenafiCertificate -Format 'PKCS #12' -PrivateKeyPassword $cred.password
 Get one or more certificates with private key included, TPP
 
 .EXAMPLE
-$cert | Get-VenafiCertificate -FriendlyName 'MyFriendlyName' -KeystorePassword $cred.password
+$cert | Export-VenafiCertificate -FriendlyName 'MyFriendlyName' -KeystorePassword $cred.password
 Get certificates in JKS format, TPP
 
 #>


### PR DESCRIPTION
Created a few fixes for exporting a certificate
- Mask `CertficateData` property in `Write-VerboseWithSecret`. Resolves #25.
- Add IncludeChain support for `JKS` in `Export-VenafiCertificate`. Fixes #24.
- Add IncludePrivateKey support for `JKS` in `Export-VenafiCertificate`. I _think_ this fixes #26).
- Update `Export-VenafiCertificate` example to correct function name.