### PR TITLE
Fix #37, add application base custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Remove validation/limitation from `Get-TppCustomField` to only retrieve classes of type X509 Certificate and Device
 - Retrieve Application Base custom fields during `New-VenafiSession`
 - Fix parameter sets in `Import-TppCertificate` requiring PrivateKey be provided with PKCS#12 certificate, [#37](https://github.com/gdbarron/VenafiPS/issues/37)
+- Add `-CertificateAuthorityAttribute` to `New-TppCertificate` to submit values to the CA during enrollment
 
 ## 3.3.0
 - Add support for local token/key storage with [PowerShell SecretManagement](https://devblogs.microsoft.com/powershell/secretmanagement-and-secretstore-are-generally-available/).  Store your access or refresh token securely and have VenafiPS use it to create a new session.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.3.1
+- Remove validation/limitation from `Get-TppCustomField` to only retrieve classes of type X509 Certificate and Device
+- Retrieve Application Base custom fields during `New-VenafiSession`
+- Fix parameter sets in `Import-TppCertificate` requiring PrivateKey be provided with PKCS#12 certificate, [#37](https://github.com/gdbarron/VenafiPS/issues/37)
+
 ## 3.3.0
 - Add support for local token/key storage with [PowerShell SecretManagement](https://devblogs.microsoft.com/powershell/secretmanagement-and-secretstore-are-generally-available/).  Store your access or refresh token securely and have VenafiPS use it to create a new session.
 - Add `Get-TppClassAttribute` to list all attributes for a specific class.  Helpful for attribute validation and getting values for all attributes.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,4 @@
 - Remove validation/limitation from `Get-TppCustomField` to only retrieve classes of type X509 Certificate and Device
 - Retrieve Application Base custom fields during `New-VenafiSession`
 - Fix parameter sets in `Import-TppCertificate` requiring PrivateKey be provided with PKCS#12 certificate, [#37](https://github.com/gdbarron/VenafiPS/issues/37)
+- Add `-CertificateAuthorityAttribute` to `New-TppCertificate` to submit values to the CA during enrollment

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,2 +1,3 @@
-- Add support for local token/key storage with [PowerShell SecretManagement](https://devblogs.microsoft.com/powershell/secretmanagement-and-secretstore-are-generally-available/).  Store your access or refresh token securely and have VenafiPS use it to create a new session.
-- Add `Get-TppClassAttribute` to list all attributes for a specific class.  Helpful for attribute validation and getting values for all attributes.
+- Remove validation/limitation from `Get-TppCustomField` to only retrieve classes of type X509 Certificate and Device
+- Retrieve Application Base custom fields during `New-VenafiSession`
+- Fix parameter sets in `Import-TppCertificate` requiring PrivateKey be provided with PKCS#12 certificate, [#37](https://github.com/gdbarron/VenafiPS/issues/37)

--- a/VenafiPS/Public/Get-TppCustomField.ps1
+++ b/VenafiPS/Public/Get-TppCustomField.ps1
@@ -3,10 +3,10 @@
 Get custom field details
 
 .DESCRIPTION
-Get details about custom fields for either certificates or devices
+Get details about custom fields
 
 .PARAMETER Class
-Class to get details on.  Value can be either Device or X509 Certificate
+Class to get details on
 
 .PARAMETER VenafiSession
 Session object created from New-VenafiSession method.  The value defaults to the script session object $VenafiSession.
@@ -51,8 +51,7 @@ function Get-TppCustomField {
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory)]
-        [ValidateSet('Device', 'X509 Certificate')]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [string] $Class,
 
         [Parameter()]

--- a/VenafiPS/Public/Import-TppCertificate.ps1
+++ b/VenafiPS/Public/Import-TppCertificate.ps1
@@ -57,8 +57,8 @@ None
 .OUTPUTS
 TppObject, if PassThru provided
 
-.NOTES
-Must have Master Admin permission or must have View, Read, Write, Create and Private Key Write permission to the Certificate object.
+.LINK
+https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-Import.php
 #>
 function Import-TppCertificate {
     [CmdletBinding(DefaultParameterSetName = 'ByFile')]
@@ -162,7 +162,6 @@ function Import-TppCertificate {
         if ( $PSBoundParameters.ContainsKey('EnrollmentAttribute') ) {
             $updatedAttribute = @($EnrollmentAttribute.GetEnumerator() | ForEach-Object { @{'Name' = $_.name; 'Value' = $_.value } })
             $params.Body.CASpecificAttributes = $updatedAttribute
-
         }
 
         if ( $Reconcile.IsPresent ) {

--- a/VenafiPS/Public/New-VenafiSession.ps1
+++ b/VenafiPS/Public/New-VenafiSession.ps1
@@ -503,11 +503,9 @@ function New-VenafiSession {
         # only applicable to tpp
         if ( $PSCmdlet.ParameterSetName -notin 'VaasKey', 'VaultVaasKey' ) {
             $newSession.Version = (Get-TppVersion -VenafiSession $newSession -ErrorAction SilentlyContinue)
-            $certFields = Get-TppCustomField -VenafiSession $newSession -Class 'X509 Certificate' -ErrorAction SilentlyContinue
-            $deviceFields = Get-TppCustomField -VenafiSession $newSession -Class 'Device' -ErrorAction SilentlyContinue
-            $allFields = $certFields.Items
-            $allFields += $deviceFields.Items | Where-Object { $_.Guid -notin $allFields.Guid }
-            $newSession.CustomField = $allFields
+            $certFields = 'X509 Certificate', 'Device', 'Application Base' | Get-TppCustomField -VenafiSession $newSession -ErrorAction SilentlyContinue
+            # make sure we remove duplicates
+            $newSession.CustomField = $certFields.Items | Sort-Object -Property Guid -Unique
         }
 
         if ( $PassThru ) {


### PR DESCRIPTION
- Remove validation/limitation from `Get-TppCustomField` to only retrieve classes of type X509 Certificate and Device
- Retrieve Application Base custom fields during `New-VenafiSession`
- Fix parameter sets in `Import-TppCertificate` requiring PrivateKey be provided with PKCS#12 certificate, [#37](https://github.com/gdbarron/VenafiPS/issues/37)
