### PR TITLE
older versions of TPP failing to update attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.1
+- Older versions of TPP failing to update attributes, [#50](https://github.com/gdbarron/VenafiPS/issues/50)
+- Fix pipeline for `-Path` parameter with `Set-TppAttribute`
+
 ## 3.5.0
 - BREAKING CHANGE: change parameter `-NewName` to `-NewPath` in `Rename-TppObject` to allow moving an object in addition to renaming
 - Add `Convert-TppObject` to change the class/type of an existing object

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,2 @@
-- BREAKING CHANGE: change parameter `-NewName` to `-NewPath` in `Rename-TppObject` to allow moving an object in addition to renaming
-- Add `Convert-TppObject` to change the class/type of an existing object
-- Fix typos in examples for `Add-TppCertificateAssociation` and `Remove-TppCertificateAssociation`
-- Set the default for `-Path` in `Find-TppObject` to \ved\policy.  Running `Find-TppObject` without a path will now recursively search from \ved\policy.
-- Add additional pipeline options to `Get-TppAttribute`
-- Add help and examples to `Invoke-VenafiRestMethod`, [#48](https://github.com/gdbarron/VenafiPS/issues/48)
-- Set VenafiSession default value in `Invoke-VenafiRestMethod`, [#47](https://github.com/gdbarron/VenafiPS/issues/47)
+- Older versions of TPP failing to update attributes, [#50](https://github.com/gdbarron/VenafiPS/issues/50)
+- Fix pipeline for `-Path` parameter with `Set-TppAttribute`

--- a/VenafiPS/Public/Set-TppAttribute.ps1
+++ b/VenafiPS/Public/Set-TppAttribute.ps1
@@ -71,7 +71,7 @@ https://docs.venafi.com/Docs/current/TopNav/Content/SDK/WebSDK/r-SDK-POST-Config
 #>
 function Set-TppAttribute {
 
-    [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Object')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Being flagged incorrectly')]
 
     param (
@@ -178,7 +178,7 @@ function Set-TppAttribute {
                 else {
                     $baseFields += @{
                         Name  = $thisKey
-                        Value = $thisValue
+                        Value = @($thisValue)
                     }
                 }
             }


### PR DESCRIPTION
- Older versions of TPP failing to update attributes, [#50](https://github.com/gdbarron/VenafiPS/issues/50)
- Fix pipeline for `-Path` parameter with `Set-TppAttribute`

closes #50 